### PR TITLE
fix(docs): muda o link do repositório em todos os locais do código após mudar o nome no github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # [Sua Grade UnB](https://suagradeunb.com.br/)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
-[![codecov](https://codecov.io/gh/unb-mds/2023-2-Squad11/branch/main/graph/badge.svg?token=ZQZQZQZQZQ)](https://codecov.io/gh/unb-mds/2023-2-Squad11)
-[![GitHub issues](https://img.shields.io/github/issues/unb-mds/2023-2-Squad11)](https://img.shields.io/github/issues/unb-mds/2023-2-Squad11)
-[![GitHub contributors](https://img.shields.io/github/contributors/unb-mds/2023-2-Squad11)](https://img.shields.io/github/contributors/unb-mds/2023-2-Squad11)
-[![GitHub stars](https://img.shields.io/github/stars/unb-mds/2023-2-Squad11)](https://img.shields.io/github/stars/unb-mds/2023-2-Squad11)
-[![Hit Counter](https://views.whatilearened.today/views/github/unb-mds/2023-2-Squad11.svg)](https://views.whatilearened.today/views/github/unb-mds/2023-2-Squad11.svg)
+[![codecov](https://codecov.io/gh/unb-mds/2023-2-SuaGradeUnB/branch/main/graph/badge.svg?token=ZQZQZQZQZQ)](https://codecov.io/gh/unb-mds/2023-2-SuaGradeUnB)
+[![GitHub issues](https://img.shields.io/github/issues/unb-mds/2023-2-SuaGradeUnB)](https://img.shields.io/github/issues/unb-mds/2023-2-SuaGradeUnB)
+[![GitHub contributors](https://img.shields.io/github/contributors/unb-mds/2023-2-SuaGradeUnB)](https://img.shields.io/github/contributors/unb-mds/2023-2-SuaGradeUnB)
+[![GitHub stars](https://img.shields.io/github/stars/unb-mds/2023-2-SuaGradeUnB)](https://img.shields.io/github/stars/unb-mds/2023-2-SuaGradeUnB)
+[![Hit Counter](https://views.whatilearened.today/views/github/unb-mds/2023-2-SuaGradeUnB.svg)](https://views.whatilearened.today/views/github/unb-mds/2023-2-SuaGradeUnB.svg)
 </br>
 
 [![Python version](https://img.shields.io/badge/python-3.11.6-blue)](https://www.python.org/downloads/release/python-3116/)
@@ -44,21 +44,21 @@ O projeto é software livre e está sob a licença [MIT](./LICENSE).
 
 ## 👥 Equipe
 
-| Nome | GitHub |
-| :--- | :----: |
-| Arthur Ribeiro e Sousa | [@artrsousa1](https://github.com/artrsousa1) |
-| Caio Falcão Habibe Costa | [@CaioHabibe](https://github.com/CaioHabibe) |
-| Caio Felipe Rocha Rodrigues| [@caio-felipee](https://github.com/caio-felipee) |
+| Nome                           |                           GitHub                           |
+| :----------------------------- | :--------------------------------------------------------: |
+| Arthur Ribeiro e Sousa         |        [@artrsousa1](https://github.com/artrsousa1)        |
+| Caio Falcão Habibe Costa       |        [@CaioHabibe](https://github.com/CaioHabibe)        |
+| Caio Felipe Rocha Rodrigues    |      [@caio-felipee](https://github.com/caio-felipee)      |
 | Gabriel Henrique Castelo Costa | [@GabrielCastelo-31](https://github.com/GabrielCastelo-31) |
-| Henrique Camelo Quenino | [@henriquecq](https://github.com/henriquecq) |
-| Mateus Vieira Rocha da Silva | [@mateusvrs](https://github.com/mateusvrs) |
+| Henrique Camelo Quenino        |        [@henriquecq](https://github.com/henriquecq)        |
+| Mateus Vieira Rocha da Silva   |         [@mateusvrs](https://github.com/mateusvrs)         |
 
 ## ✨ Início
 
 Você pode clonar o repositório do projeto com o seguinte comando:
 
 ```bash
-git clone https://github.com/unb-mds/2023-2-Squad11.git
+git clone https://github.com/unb-mds/2023-2-SuaGradeUnB.git
 ```
 
 ### 📋 Pré-requisitos
@@ -150,15 +150,15 @@ A obtenção dos dados das disciplinas é feita através de um _web scraping_ no
 make updatedb-all
 
 # Comando equivalente
-docker exec django-api ./manage.py updatedb -a
+docker exec django-api python3 ./manage.py updatedb -a
 ```
 
 ### 🖱️ Acesso aos serviços
 
-| Serviço | URL |
-| :--- | :----: |
+| Serviço  |                      URL                       |
+| :------- | :--------------------------------------------: |
 | Frontend | [http://localhost:3000](http://localhost:3000) |
-| Backend | [http://localhost:8000](http://localhost:8000) |
+| Backend  | [http://localhost:8000](http://localhost:8000) |
 
 ### 📍 Migrations
 
@@ -176,7 +176,7 @@ make migrate
 
 ## 📚 Documentação
 
-A documentação do projeto pode ser encontrada clicando [aqui](https://unb-mds.github.io/2023-2-Squad11/).
+A documentação do projeto pode ser encontrada clicando [aqui](https://unb-mds.github.io/2023-2-SuaGradeUnB/).
 
 ## 📎 Extra
 

--- a/api/core/urls.py
+++ b/api/core/urls.py
@@ -38,7 +38,7 @@ schema_view = get_schema_view(
                 <li>Mateus Vieira Rocha da Silva (<a target='_blank' href='https://github.com/mateusvrs'>@mateusvrs</a>)</li>
             </ul>
             </br>
-            Mais especificações sobre o projeto por completo podem ser encontradas <a href='https://github.com/unb-mds/2023-2-Squad11/'>aqui</a>.
+            Mais especificações sobre o projeto por completo podem ser encontradas <a href='https://github.com/unb-mds/2023-2-SuaGradeUnB/'>aqui</a>.
         </div>
         """,
         contact=openapi.Contact(email="suagradeunb@gmail.com"),

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,19 +11,19 @@ Para contribuir com o projeto, basta seguir os passos abaixo:
 
 **Encontrando um problema:**
 
-Se você identificar um problema na aplicação, verifique se já existe um problema relacionado. Se não existir, você pode abrir uma nova issue de **Bug Report** utilizando o [template disponível](https://github.com/unb-mds/2023-2-Squad11/issues/new/choose). Adicione o _label_ de `bug` a issue e siga as instruções contidas no template.
+Se você identificar um problema na aplicação, verifique se já existe um problema relacionado. Se não existir, você pode abrir uma nova issue de **Bug Report** utilizando o [template disponível](https://github.com/unb-mds/2023-2-SuaGradeUnB/issues/new/choose). Adicione o _label_ de `bug` a issue e siga as instruções contidas no template.
 
 **Resolver um problema:**
 
-Dê uma olhada em nossas [issues](https://github.com/unb-mds/2023-2-Squad11/issues) para encontrar uma que lhe interesse. Você pode refinar a pesquisa usando as `labels` como filtros e, se for a sua primeira issue, tente procurar por `good first issue`. Se encontrar um problema disponível para trabalhar, você é bem-vindo para abrir um [Pull Request](#pull-request).
+Dê uma olhada em nossas [issues](https://github.com/unb-mds/2023-2-SuaGradeUnB/issues) para encontrar uma que lhe interesse. Você pode refinar a pesquisa usando as `labels` como filtros e, se for a sua primeira issue, tente procurar por `good first issue`. Se encontrar um problema disponível para trabalhar, você é bem-vindo para abrir um [Pull Request](#pull-request).
 
 **Encontrando erros na documentação**
 
-Caso você encontre algum erro na documentação, você pode abrir uma nova issue de **Docs repair** utilizando o [template disponível](https://github.com/unb-mds/2023-2-Squad11/issues/new/choose). Adicione o _label_ de `docs` a issue e siga as instruções contidas no template.
+Caso você encontre algum erro na documentação, você pode abrir uma nova issue de **Docs repair** utilizando o [template disponível](https://github.com/unb-mds/2023-2-SuaGradeUnB/issues/new/choose). Adicione o _label_ de `docs` a issue e siga as instruções contidas no template.
 
 **Como propor novas funcionalidades**
 
-Para propor uma melhoria ou nova funcionalidade, você pode abrir uma nova issue de **Feature Request** utilizando o [template disponível](https://github.com/unb-mds/2023-2-Squad11/issues/new/choose) e adcionar o _label_ de `feature request` a issue. Sua sugestão será analisada e, se aprovada, será aberta uma _task_ para a implementação desta nova funcionalidade.
+Para propor uma melhoria ou nova funcionalidade, você pode abrir uma nova issue de **Feature Request** utilizando o [template disponível](https://github.com/unb-mds/2023-2-SuaGradeUnB/issues/new/choose) e adcionar o _label_ de `feature request` a issue. Sua sugestão será analisada e, se aprovada, será aberta uma _task_ para a implementação desta nova funcionalidade.
 
 **Como fazer alterações?**
 
@@ -36,7 +36,7 @@ Para fazer alterações você deve, primeiramente, seguir os passos para [execut
 
 Quando terminar as alterações, crie uma pull request (PR).
 
-- Não se esqueça de [vincular o PR a uma issue](https://github.com/unb-mds/2023-2-Squad11/issues) se estiver resolvendo uma.
+- Não se esqueça de [vincular o PR a uma issue](https://github.com/unb-mds/2023-2-SuaGradeUnB/issues) se estiver resolvendo uma.
 - Assim que enviar seu PR, um membro da equipe revisará sua proposta. Podemos fazer perguntas ou solicitar informações adicionais.
 - Podemos solicitar alterações antes que um PR possa ser aceito.
 - Conforme você atualiza seu PR e aplica alterações, marque cada conversa como [resolvida](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#resolving-conversations).

--- a/docs/executing.md
+++ b/docs/executing.md
@@ -10,7 +10,7 @@ hide:
 Você pode clonar o repositório do projeto com o seguinte comando:
 
 ```bash
-git clone https://github.com/unb-mds/2023-2-Squad11.git
+git clone https://github.com/unb-mds/2023-2-SuaGradeUnB.git
 ```
 
 ### 📋 Pré-requisitos

--- a/docs/sprints/sprint-5.md
+++ b/docs/sprints/sprint-5.md
@@ -22,7 +22,7 @@ Local: Gather Town
 
 **Ata:**
 
-Nessa reunião, o time do _Front-end_ finalizou a apresentação do [protótipo de alta fidelidade](https://www.figma.com/proto/o5Ffh1fWmmQz7KcDGuHrVP/Sua-grade-UNB?type=design&node-id=16-2775&scaling=scale-down&page-id=0%3A1&mode=design&t=vdtHhHY0NWBuOQwZ-1) do projeto, e o time de _Back-end_ apresentou as [rotas](https://unb-mds.github.io/2023-2-Squad11/api/) da API organizadas e definidas para todos os escopos necessários no projeto.
+Nessa reunião, o time do _Front-end_ finalizou a apresentação do [protótipo de alta fidelidade](https://www.figma.com/proto/o5Ffh1fWmmQz7KcDGuHrVP/Sua-grade-UNB?type=design&node-id=16-2775&scaling=scale-down&page-id=0%3A1&mode=design&t=vdtHhHY0NWBuOQwZ-1) do projeto, e o time de _Back-end_ apresentou as [rotas](https://unb-mds.github.io/2023-2-SuaGradeUnB/api/) da API organizadas e definidas para todos os escopos necessários no projeto.
 
 ## Finalização
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Docs - Sua Grade UnB
-repo_url: https://github.com/unb-mds/2023-2-Squad11
+repo_url: https://github.com/unb-mds/2023-2-SuaGradeUnB
 
 nav:
   - Home: index.md

--- a/web/app/schedules/info/page.tsx
+++ b/web/app/schedules/info/page.tsx
@@ -66,7 +66,7 @@ function HowToContribute() {
         <>
             <h2 className="text-3xl font-semibold  pt-5 pb-5">Como contribuir?</h2>
             <p className="text-justify">
-                Se você é um programador e deseja contribuir com nosso projeto, basta <Link legacyBehavior href="https://unb-mds.github.io/2023-2-Squad11/contributing/" className=""><a target="_blank" className="text-primary hover:underline">clicar aqui</a></Link> para ter acesso a nossa documentação. Lá você encontrará todos os detalhes de como contribuir com novas funcionalidades e reportar possíveis erros.
+                Se você é um programador e deseja contribuir com nosso projeto, basta <Link legacyBehavior href="https://unb-mds.github.io/2023-2-SuaGradeUnB/contributing/" className=""><a target="_blank" className="text-primary hover:underline">clicar aqui</a></Link> para ter acesso a nossa documentação. Lá você encontrará todos os detalhes de como contribuir com novas funcionalidades e reportar possíveis erros.
             </p>
         </>
     );


### PR DESCRIPTION
**O que foi feito?**
- Após a modificação do nome do repositório no GitHub foi necessário atualizar o link nos locais o qual o mesmo era utilizado tanto nos códigos quanto na documentação do projeto