### PR TITLE
task(api): otimiza piores e médios casos da atualização do db por meio de redis cache, pages fingerprints e multithreading

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -17,6 +17,9 @@ POSTGRES_DB="postgres"
 POSTGRES_USER="suagradeunb"
 POSTGRES_PASSWORD="suagradeunb"
 
+# Redis
+REDIS_CACHE_LOCATION="redis://redis:6379/1"
+
 # Credenciais de acesso ao admin
 ADMIN_NAME="admin"
 ADMIN_PASS="admin"

--- a/api/api/decorators.py
+++ b/api/api/decorators.py
@@ -13,7 +13,7 @@ def handle_cache_before_delete(query_func: callable) -> callable:
             for query in queryset:
                 cache_key = query.get_cache_key()
                 cache.delete(cache_key)
-        except:
+        except: # pragma: no cover
             raise ValueError(cache_error_msg)
         else:
             queryset.delete()

--- a/api/api/decorators.py
+++ b/api/api/decorators.py
@@ -1,0 +1,21 @@
+from django.core.cache import cache
+from api.models import cache_error_msg
+import functools
+
+
+def handle_cache_before_delete(query_func: callable) -> callable:
+
+    @functools.wraps(query_func)
+    def wrapper(*args, **kwargs):
+        queryset = query_func(*args, **kwargs)
+
+        try:
+            for query in queryset:
+                cache_key = query.get_cache_key()
+                cache.delete(cache_key)
+        except:
+            raise ValueError(cache_error_msg)
+        else:
+            queryset.delete()
+
+    return wrapper

--- a/api/api/management/commands/updatedb.py
+++ b/api/api/management/commands/updatedb.py
@@ -8,6 +8,7 @@ from utils.web_scraping import DisciplineWebScraper, get_list_of_departments
 from django.core.cache import cache
 from time import time, sleep
 from collections import deque
+from core.settings.base import THIRTY_DAYS_IN_SECS
 import threading
 
 
@@ -118,8 +119,7 @@ class Command(BaseCommand):
                         print(f"Departamento ({department_id}) atualizado, operação não necessária")
                     return
 
-                THIRTY_DAYS = 30 * 86400
-                cache.set(cache_key, fingerprint, timeout=THIRTY_DAYS)
+                cache.set(cache_key, fingerprint, timeout=THIRTY_DAYS_IN_SECS)
             except:
                 print("Ocorreu um erro ao tentar acessar o cache")
                 pass

--- a/api/api/management/commands/updatedb.py
+++ b/api/api/management/commands/updatedb.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
                 self.display_success_update_message(
                     operation=f"{year}/{period}", start_time=start_time)
             except Exception as exception:
-                print("Houve um erro na atualização do bando de dados.")
+                print("Houve um erro na atualização do banco de dados.")
                 print(f"Error: {exception}")
 
         start_tot_time = time()

--- a/api/api/management/commands/updatedb.py
+++ b/api/api/management/commands/updatedb.py
@@ -111,15 +111,13 @@ class Command(BaseCommand):
             scraper = DisciplineWebScraper(department_id, year, period)
             fingerprint = scraper.create_page_fingerprint()
 
+            cache_key = f"{department_id}/{year}.{period}"
             try:
-                cache_key = f"{department_id}/{year}.{period}"
                 cache_value = cache.get(cache_key)
                 if cache_value and cache_value == fingerprint:
                     if options['descriptive']:
                         print(f"Departamento ({department_id}) atualizado, operação não necessária")
                     return
-
-                cache.set(cache_key, fingerprint, timeout=THIRTY_DAYS_IN_SECS)
             except:
                 print("Ocorreu um erro ao tentar acessar o cache")
                 pass
@@ -147,9 +145,11 @@ class Command(BaseCommand):
                                      classroom=class_info["classroom"], schedule=class_info["schedule"],
                                      days=class_info["days"], _class=class_info["class_code"], discipline=discipline, special_dates=class_info["special_dates"])
 
+            cache.set(cache_key, fingerprint, timeout=THIRTY_DAYS_IN_SECS)
+            
             if options['descriptive']:
                 print(f'Operação de atualização finalizada para o departamento ({department_id})')
-
+            
         threads = deque()
         for department_id in departments_ids:
             thread = threading.Thread(

--- a/api/api/management/commands/updatedb.py
+++ b/api/api/management/commands/updatedb.py
@@ -1,8 +1,10 @@
 from typing import Any
 from argparse import ArgumentParser as CommandParser
 from django.core.management.base import BaseCommand
-from utils import sessions, web_scraping
-from utils.db_handler import delete_classes_from_discipline, delete_all_departments_using_year_and_period, get_or_create_department, get_or_create_discipline, create_class
+from utils import sessions
+from utils import db_handler as dbh
+from utils.web_scraping import DisciplineWebScraper, get_list_of_departments
+from django.core.cache import cache
 from time import time
 
 
@@ -13,8 +15,11 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser: CommandParser) -> None:
         """Adiciona os argumentos do comando."""
-        parser.add_argument('-a', '-all', action='store_true', dest='all', default=False,
+        parser.add_argument('-a', '--all', action='store_true', dest='all', default=False,
                             help="Atualiza o banco de dados com as disciplinas dos períodos atual e seguinte.")
+        
+        parser.add_argument('-ds', '--descriptive', action='store_true', default=False,
+                    help="Ativa a opção de uma atualização descritiva com os outputs (print) necessários")
 
         parser.add_argument('-p', '--period', action='store', default=None,
                             choices=[".".join(sessions.get_current_year_and_period()), ".".join(
@@ -37,11 +42,11 @@ class Command(BaseCommand):
             print("Utilize o comando 'updatedb -h' para mais informações.")
             return
 
-        # Obtem o ano e o período anterior ao período atual
+        # Obtém o ano e o período anterior ao período atual
         previous_period_year, previous_period = sessions.get_previous_period()
 
         # Apaga as disciplinas do período anterior
-        delete_all_departments_using_year_and_period(
+        dbh.delete_all_departments_using_year_and_period(
             year=previous_period_year, period=previous_period)
 
         if options["delete"]:
@@ -49,7 +54,7 @@ class Command(BaseCommand):
                 self.delete_period(year=year, period=period)
             return
 
-        departments_ids = web_scraping.get_list_of_departments()
+        departments_ids = get_list_of_departments()
 
         if departments_ids is None:
             self.display_error_message("department_ids")
@@ -60,44 +65,64 @@ class Command(BaseCommand):
         for year, period in choices:
             try:
                 start_time = time()
-                self.update_departments(
-                    departments_ids=departments_ids, year=year, period=period)
+                print(f"Começando atualização de {year}/{period}")
+                self.update_departments(departments_ids, year, period, options)
                 self.display_success_update_message(
                     operation=f"{year}/{period}", start_time=start_time)
             except Exception as exception:
                 print("Houve um erro na atualização do bando de dados.")
                 print(f"Error: {exception}")
 
-    def update_departments(self, departments_ids: list, year: str, period: str) -> None:
+    def update_departments(self, departments_ids: list, year: str, period: str, options: Any) -> None:
         """Atualiza os departamentos do banco de dados e suas respectivas disciplinas."""
         for department_id in departments_ids:
-            print(f"WebScraping do departamento: {department_id}")
-            disciplines_list = web_scraping.get_department_disciplines(
-                department_id=department_id, current_year=year, current_period=period)
-            department = get_or_create_department(
+            scraper = DisciplineWebScraper(department_id, year, period)
+            fingerprint = scraper.create_page_fingerprint()
+
+            try:
+                cache_key = f"{department_id}/{year}.{period}"
+                cache_value = cache.get(cache_key)
+                if cache_value and cache_value == fingerprint:
+                    if options['descriptive']:
+                        print(f"Departamento ({department_id}) atualizado, operação não necessária")
+                    continue
+
+                THIRTY_DAYS = 30 * 86400
+                cache.set(cache_key, fingerprint, timeout=THIRTY_DAYS)
+            except:
+                print("Ocorreu um erro ao tentar acessar o cache")
+                pass
+
+            disciplines_list = scraper.get_disciplines()
+            department = dbh.get_or_create_department(
                 code=department_id, year=year, period=period)
 
-            print("Atualizando disciplinas do departamento...")
+            if options['descriptive']:
+                print(f"Departamento ({department_id}) desatualizado, operação necessária")
             # Para cada disciplina do período atual, deleta as turmas previamente cadastradas e cadastra novas turmas no banco de dados
             for discipline_code in disciplines_list:
                 classes_info = disciplines_list[discipline_code]
                 # Cria ou pega a disciplina
-                discipline = get_or_create_discipline(
+                discipline = dbh.get_or_create_discipline(
                     name=classes_info[0]["name"], code=discipline_code, department=department)
 
                 # Deleta as turmas previamente cadastradas
-                delete_classes_from_discipline(discipline=discipline)
+                dbh.delete_classes_from_discipline(discipline=discipline)
 
                 # Cadastra as novas turmas
                 for class_info in classes_info:
-                    create_class(teachers=class_info["teachers"],
-                                 classroom=class_info["classroom"], schedule=class_info["schedule"],
-                                 days=class_info["days"], _class=class_info["class_code"], discipline=discipline, special_dates=class_info["special_dates"])
+                    dbh.create_class(teachers=class_info["teachers"],
+                                     classroom=class_info["classroom"], schedule=class_info["schedule"],
+                                     days=class_info["days"], _class=class_info["class_code"], discipline=discipline, special_dates=class_info["special_dates"])
+                    
+            if options['descriptive']:
+                print(f'Operação de atualização finalizada para o departamento ({department_id})')
 
     def delete_period(self, year: str, period: str) -> None:
         """Deleta um período do banco de dados."""
         start_time = time()
-        delete_all_departments_using_year_and_period(year=year, period=period)
+        dbh.delete_all_departments_using_year_and_period(
+            year=year, period=period)
         self.display_success_delete_message(
             operation=f"{year}/{period}", start_time=start_time)
 

--- a/api/api/models.py
+++ b/api/api/models.py
@@ -16,7 +16,7 @@ class CustomModel(models.Model):
         try:
             cache.delete(kwargs['cache_key'])
             kwargs.pop('cache_key')
-        except:
+        except: # pragma: no cover
             raise ValueError(cache_error_msg)
         else:
             super(CustomModel, self).delete()

--- a/api/api/models.py
+++ b/api/api/models.py
@@ -3,8 +3,27 @@ from unidecode import unidecode
 from django.contrib.postgres.fields import ArrayField
 from users.models import User
 from django.utils import timezone
+from django.core.cache import cache
 
-class Department(models.Model):
+cache_error_msg = "Cache isn't working properly, so database isn't allowed to be modified!"
+
+
+class CustomModel(models.Model):
+    class Meta:
+        abstract = True
+
+    def delete(self, *args, **kwargs):
+        try:
+            cache.delete(kwargs['cache_key'])
+            kwargs.pop('cache_key')
+        except:
+            raise ValueError(cache_error_msg)
+        else:
+            super(CustomModel, self).delete()
+            pass
+
+
+class Department(CustomModel):
     """Classe que representa um departamento.
     code:str -> Código do departamento
     year:str -> Ano do departamento
@@ -17,8 +36,19 @@ class Department(models.Model):
     def __str__(self):
         return self.code
 
+    def get_cache_key(self):
+        code = self.code
+        year = self.year
+        period = self.period
 
-class Discipline(models.Model):
+        return f"{code}/{year}.{period}"
+
+    def delete(self, *args, **kwargs):
+        kwargs['cache_key'] = self.get_cache_key()
+        super(Department, self).delete(*args, **kwargs)
+
+
+class Discipline(CustomModel):
     """Classe que representa uma disciplina.
     name:str -> Nome da disciplina
     unicode_name:str -> Nome da disciplina normalizado
@@ -38,8 +68,19 @@ class Discipline(models.Model):
         self.unicode_name = unidecode(self.name).casefold()
         super(Discipline, self).save(*args, **kwargs)
 
+    def get_cache_key(self):
+        code = self.department.code
+        year = self.department.year
+        period = self.department.period
 
-class Class(models.Model):
+        return f"{code}/{year}.{period}"
+
+    def delete(self, *args, **kwargs):
+        kwargs['cache_key'] = self.get_cache_key()
+        super(Discipline, self).delete(*args, **kwargs)
+
+
+class Class(CustomModel):
     """Classe que representa uma turma.
     teachers:list -> Lista de professores da turma
     classroom:str -> Sala da turma
@@ -66,6 +107,17 @@ class Class(models.Model):
 
     def __str__(self):
         return self._class
+
+    def get_cache_key(self):
+        code = self.discipline.department.code
+        year = self.discipline.department.year
+        period = self.discipline.department.period
+
+        return f"{code}/{year}.{period}"
+
+    def delete(self, *args, **kwargs):
+        kwargs['cache_key'] = self.get_cache_key()
+        super(Class, self).delete(*args, **kwargs)
 
 
 class Schedule(models.Model):

--- a/api/api/tests/test_models.py
+++ b/api/api/tests/test_models.py
@@ -1,9 +1,10 @@
 from django.test import TestCase
+from django.core.cache import cache
 from api.models import Department, Discipline, Class
 
 
-class DisciplineModelsTest(TestCase):
-    def setUp(self):
+class ModelsTest(TestCase):
+    def create_data(self):
         self.department = Department.objects.create(
             code='INF',
             year="2023",
@@ -23,6 +24,11 @@ class DisciplineModelsTest(TestCase):
             _class="1",
             discipline=self.discipline
         )
+
+        cache.set("INF/2023.2", "hash_value")
+
+    def setUp(self):
+        self.create_data()
 
     def test_create_discipline(self):
         self.assertEqual(self.discipline.name,
@@ -52,3 +58,31 @@ class DisciplineModelsTest(TestCase):
 
     def test_str_method_of_department(self):
         self.assertEqual(str(self.department), self.department.code)
+
+    def test_delete_department_with_cache_handle(self):
+        self.department.delete()
+
+        empty_model = not len(Department.objects.all())
+        empty_cache = not len(cache.keys('*'))
+
+        self.assertTrue(empty_model)
+        self.assertTrue(empty_cache)
+
+    def test_delete_discipline_with_cache_handle(self):
+        self.discipline.delete()
+
+        empty_model = not len(Discipline.objects.all())
+        empty_cache = not len(cache.keys('*'))
+
+        self.assertTrue(empty_model)
+        self.assertTrue(empty_cache)
+
+    def test_delete_class_with_cache_handle(self):
+        self._class.delete()
+
+        empty_model = not len(Class.objects.all())
+        empty_cache = not len(cache.keys('*'))
+
+        self.assertTrue(empty_model)
+        self.assertTrue(empty_cache)
+    

--- a/api/core/settings/base.py
+++ b/api/core/settings/base.py
@@ -47,6 +47,13 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt.token_blacklist'
 ]
 
+# Time constants
+
+HOUR_IN_SECS = 60 * 60
+HALF_DAY_IN_SECS = 12 * HOUR_IN_SECS
+DAY_IN_SECS = 24 * HOUR_IN_SECS
+THIRTY_DAYS_IN_SECS = 30 * DAY_IN_SECS
+
 # Cache
 # https://docs.djangoproject.com/en/5.0/topics/cache/
 
@@ -56,7 +63,8 @@ CACHES = {
         "LOCATION": config("REDIS_CACHE_LOCATION"),
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        }
+        },
+        "TIMEOUT": HALF_DAY_IN_SECS
     }
 }
 

--- a/api/core/settings/base.py
+++ b/api/core/settings/base.py
@@ -47,6 +47,22 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt.token_blacklist'
 ]
 
+# Cache
+# https://docs.djangoproject.com/en/5.0/topics/cache/
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": config("REDIS_CACHE_LOCATION"),
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        }
+    }
+}
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+SESSION_CACHE_ALIAS = "default"
+
 # Authentication
 
 AUTH_USER_MODEL = 'users.User'

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -15,6 +15,7 @@ defusedxml==0.7.1
 dj-database-url==2.1.0
 Django==4.2.7
 django-cors-headers==4.3.0
+django-redis==5.4.0
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.3.0
 drf-yasg==1.21.7
@@ -51,6 +52,7 @@ python3-openid==3.2.0
 pytz==2023.3.post1
 PyYAML==6.0.1
 pyyaml_env_tag==0.1
+redis==5.0.1
 regex==2023.8.8
 requests==2.31.0
 rsa==4.9

--- a/api/utils/db_handler.py
+++ b/api/utils/db_handler.py
@@ -1,6 +1,7 @@
 from api.models import Discipline, Department, Class
 from api.serializers import ClassSerializerSchedule
 from api.models import Schedule
+from api.decorators import handle_cache_before_delete
 
 from users.models import User
 
@@ -30,15 +31,16 @@ def create_class(teachers: list, classroom: str, schedule: str,
     return Class.objects.create(teachers=teachers, classroom=classroom, schedule=schedule,
                                 days=days, _class=_class, special_dates=special_dates, discipline=discipline)
 
-
-def delete_classes_from_discipline(discipline: Discipline) -> None:
+@handle_cache_before_delete
+def delete_classes_from_discipline(discipline: Discipline) -> QuerySet:
     """Deleta todas as turmas de uma disciplina."""
-    Class.objects.filter(discipline=discipline).delete()
+    return Class.objects.filter(discipline=discipline)
 
 
-def delete_all_departments_using_year_and_period(year: str, period: str) -> None:
+@handle_cache_before_delete
+def delete_all_departments_using_year_and_period(year: str, period: str) -> QuerySet:
     """Deleta um departamento de um periodo especifico."""
-    Department.objects.filter(year=year, period=period).delete()
+    return Department.objects.filter(year=year, period=period)
 
 
 def get_best_similarities_by_name(name: str, disciplines: Discipline = Discipline.objects, config="portuguese_unaccent") -> QuerySet:

--- a/api/utils/functions.py
+++ b/api/utils/functions.py
@@ -1,0 +1,14 @@
+import re
+
+
+def multiple_replace(text, replacement=None):
+    replacement_dict = replacement
+    if not replacement: # pragma: no cover
+        replacement_dict = {
+            '\n': '',
+            '\t': '',
+            '\r': '',
+        }
+
+    pattern = re.compile('|'.join(map(re.escape, replacement_dict.keys())))
+    return pattern.sub(lambda match: replacement_dict[match.group(0)], text)

--- a/api/utils/management/commands/updatemock.py
+++ b/api/utils/management/commands/updatemock.py
@@ -4,22 +4,9 @@ from random import choice
 from utils import sessions as sns, web_scraping as wbp
 from django.core.management.base import BaseCommand
 from pathlib import Path
-import re
+from utils.functions import multiple_replace
 import json
 import os
-
-
-def multiple_replace(text, replacement=None):
-    replacement_dict = replacement
-    if not replacement:
-        replacement_dict = {
-            '\n': '',
-            '\t': '',
-            '\r': '',
-        }
-    
-    pattern = re.compile('|'.join(map(re.escape, replacement_dict.keys())))
-    return pattern.sub(lambda match: replacement_dict[match.group(0)], text)
 
 
 class Command(BaseCommand):

--- a/api/utils/management/commands/updatemock.py
+++ b/api/utils/management/commands/updatemock.py
@@ -9,6 +9,19 @@ import json
 import os
 
 
+def multiple_replace(text, replacement=None):
+    replacement_dict = replacement
+    if not replacement:
+        replacement_dict = {
+            '\n': '',
+            '\t': '',
+            '\r': '',
+        }
+    
+    pattern = re.compile('|'.join(map(re.escape, replacement_dict.keys())))
+    return pattern.sub(lambda match: replacement_dict[match.group(0)], text)
+
+
 class Command(BaseCommand):
     """Comando para atualizar os arquivos de mock do SIGAA."""
 
@@ -33,7 +46,7 @@ class Command(BaseCommand):
                     department, current_year, current_period)
                 response = discipline_scraper.get_response_from_disciplines_post_request()
 
-                striped_response = self.multiple_replace(
+                striped_response = multiple_replace(
                     self.response_decode(response))
                 mock_file.write(striped_response)
 
@@ -48,15 +61,6 @@ class Command(BaseCommand):
         except Exception as error:
             print('Não foi possível atualizar o mock!')
             print('Error:', error)
-
-    def multiple_replace(self, text):
-        replacement_dict = {
-            '\n': '',
-            '\t': '',
-            '\r': '',
-        }
-        pattern = re.compile('|'.join(map(re.escape, replacement_dict.keys())))
-        return pattern.sub(lambda match: replacement_dict[match.group(0)], text)
 
     def response_decode(self, response: Response) -> str:
         encoding = response.encoding if response.encoding else 'utf-8'

--- a/api/utils/web_scraping.py
+++ b/api/utils/web_scraping.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 from collections import defaultdict
 from typing import List, Optional, Iterator
 from re import findall, finditer
-from utils.management.commands import updatemock
+from utils.functions import multiple_replace
 import requests.utils
 import requests
 import hashlib
@@ -252,7 +252,7 @@ class DisciplineWebScraper:
         if not tables:
             return "not_content"
 
-        treated_tables = updatemock.multiple_replace(tables.get_text(), replacement={
+        treated_tables = multiple_replace(tables.get_text(), replacement={
             '\n': '',
             '\t': '',
             '\r': '',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     env_file:
       - ./api/.env
 
+  redis:
+    image: redis:alpine
+    container_name: rediscache
+
   api:
     restart: unless-stopped
     container_name: django-api
@@ -22,7 +26,8 @@ services:
       - 8000:8000
     depends_on:
       - db
-    
+      - redis
+
   web:
     restart: unless-stopped
     container_name: nextjs-web


### PR DESCRIPTION
**Objetivo:**
A função de atualizar o banco de dados sempre passava por todas as aulas de cada disciplina encontrada em um departamento da UnB, entretando isso consome tempo e requests do banco de dados. Dessa forma, foi utilizado um cache Redis para otimizar os casos médios dessa atualização da seguinte forma:

Um certo departamento somente precisa ser atualizado quando for modificado. Para verificar a atualização de um departamento podemos guardar o HTML de casa página e fazer uma verificação linear em todo seu conteúdo verificando `char` por `char`, mas isso não seria eficiente em memória. Em tempo é, em geral, melhor que uma requisição ao banco de dados, visto que uma página do SIGAA não tem mais que 2*10^5 chars. Dessa forma, podemos ao invés de guardar todo o HTML, guardar apenas um hash (sha256) da página em um cache Redis, o qual contém apenas 256 chars. Assim, vamos fazer uma única vista linear na página atual para criar o novo hash e logo após uma verificação constante de 256 para comparação, além disso, uma única busca ao cache ao invés diversos requests desnecessários ao banco de dados.

Além disso, após algumas análises foi implementado o mecanismo de multithreading, sendo uma thread para executar cada ano/período e 3 threads que podem ser utilizadas ao mesmo tempo em cada uma dessas de ano/período, ou seja, como temos até 2 ano/período sendo atualizados ao mesmo tempo, teremos até 8 threads ativas. Uma preocupação que foi invalidada foi a de overleaping de informações durante a atualização do banco de dados, mas observa-se que isso não ocorre visto que cada thread atualiza apenas um departamento por vez e cada departamento não tem interação com o outro, o que impossibilita esse overleaping de informações.

**O que foi feito?**
- Criado um cache Redis no Redis Labs com free tier para 30MB, o armazenamento não é um problema, todos os hashes não passam de 1MB de memória
- Configurado o arquivo `settings/base.py` para o Django usar o Redis Labs
- Adicionada a config var ao Heroku para usar o Redis Labs em produção
- Configurado o Redis para desenvolvimento no container Docker
- Adicionada verificação com caching para melhor performance no `updatedb.py`
- Adiciona multithreading na execução do web scraping do `updatedb.py`

**Testes:**

Caching:
![Screenshot from 2023-12-26 20-45-07](https://github.com/unb-mds/2023-2-SuaGradeUnB/assets/68292695/4a5e8ccc-12c6-45da-a055-16e967ae402f)

O primeiro teste é uma inicialização do cache em que nenhuma página ainda estava guardada no Redis, os 2 seguintes já são com o cache atualizado e com as informações guardadas. Assim, podemos ver uma redução de cerca de 20%-35%, no geral.

Multithreading + Caching:
![image](https://github.com/unb-mds/2023-2-SuaGradeUnB/assets/68292695/0a79706a-24f9-4669-a9d8-de3d3c0f6a97)

Novamente o primeiro teste foi uma inicialização do cache e os 2 seguintes já são com o cache atualizado, mas agora o multithreading também está ativo. Logo, podemos ver uma redução de cerca de 40%-50%, no geral. E mais incrivel ainda observa-se uma queda de 60%-80% entre a não utilização e a utilização do multithreading, isso uma vez que antes o tempo era a soma dos dois anos/períodos e agora não.

Caching (1): 72.4s + 104.6s =  177s
Multithreading + Caching (1): 59.3s

177 - 177 * 0.67 = 58,41s
Sendo 0.67 igual a 67%

Não foram utilizadas mais threads devido a limitação do servidor de produção e melhoras não tão significativas para as possíveis perdas no ambiente de produção.

#

É importante lembrar que os testes foram feitos em ambiente de desenvolvimento com banco de dados local, mas com Redis cache de produção, ou seja, a diferença pode ser ainda maior visto que no ambiente de produção total o banco de dados levaria mais tempo para responder aos requests.

Além disso, é relevante dizer que os números podem enganar e por isso devem ser feitos vários testes visto que o SIGAA pode em alguma atualização atrasar mais que em outras e ficar parecendo que a utilização do cache é pior ou é extremamente melhor, mas na verdade esse efeito foi ulguma requisição que demorou mais ou menos do que o normal em algum teste de atualização no banco de dados. O que podemos perceber é que no geral a utilização do cache realmente diminuiu o tempo  de execução.

**Obs:** Devido a manipulação das páginas do SIGAA no web scraping pode acontecer de páginas sem modificações apresentarem hashes diferentes devido algum mínimo detalhe de correção do web scraping, entretanto isso não atrapalha a performance visto que foram vistas poucas dessas ocorrências. Além disso, páginas com diferenças não apresentam o mesmo hash, mas páginas igual podem apresentar devido a manipulação do web scraping, ou seja, se hover uma mudança nas disciplinas essa página não vai deixar de ser atualizada, o que pode ocorrer é a atualização desnecessária que já ocorria anteriormente.