### PR TITLE
fix(api): arruma função de ano/período atual que tinha incosistência nos dias 30/31 de dez

### DIFF
--- a/api/utils/sessions.py
+++ b/api/utils/sessions.py
@@ -43,20 +43,16 @@ def get_session_cookie(session: Session) -> cookies.RequestsCookieJar: # pragma:
     return cookie_jar
 
 """Obtem o ano e o período atual e retorna uma lista com esses valores."""
-def get_current_year_and_period(date: datetime | None = None) -> List[str | str]:
-    current_date = datetime.now()
-    if date is not None:
-        current_date = date
+def get_current_year_and_period(date: datetime | None = datetime.now()) -> List[str | str]:
+    if date is None:
+        date = datetime.now()
     
-    current_year = current_date.year
+    current_year = date.year
     period = "1"
 
-    # Se a data atual estiver entre 1 de maio e 30 de dezembro, o período é 2.
-    if datetime(current_year, 5, 1) <= current_date <= datetime(current_year, 12, 30):
+    # Se a data atual estiver entre 2 de maio e 1 de janeiro do próximo ano, o período é 2.
+    if datetime(current_year, 5, 2) <= date <= datetime(current_year + 1, 1, 1):
         period = "2"
-    # elif current_date > datetime(current_year, 10, 30):
-    #     current_year += 1
-    #     period = "1"
 
     return [str(current_year), period]
 

--- a/api/utils/tests/test_date_utils.py
+++ b/api/utils/tests/test_date_utils.py
@@ -2,11 +2,12 @@ from rest_framework.test import APITestCase
 from utils import sessions as sns
 from datetime import datetime
 
+
 class DateUtilsTest(APITestCase):
 
     def compare_date(self, date: datetime):
-        before_dec = datetime(date.year, 12, 30) >= date
-        after_may = datetime(date.year, 5, 1) <= date
+        before_dec = datetime(date.year + 1, 1, 1) >= date
+        after_may = datetime(date.year, 5, 2) <= date
 
         return before_dec and after_may
 
@@ -14,14 +15,48 @@ class DateUtilsTest(APITestCase):
         month = 2 if self.compare_date(date) else 6
         return datetime(date.year + self.compare_date(date), month=month, day=1)
 
-    def test_get_current_year_and_period(self):
-        year, period = sns.get_current_year_and_period()
+    def test_get_current_year_and_period_with_right_may_limits(self):
+        year, period = sns.get_current_year_and_period(datetime(2023, 5, 1))
 
-        date = datetime.now()
-        self.assertEqual(year, str(date.year))
+        self.assertEqual("2023", year)
+        self.assertEqual("1", period)
 
-        self.assertEqual((period == '2'), self.compare_date(date))
-        self.assertEqual((period == '1'), not self.compare_date(date))
+        year, period = sns.get_current_year_and_period(datetime(2023, 5, 2))
+
+        self.assertEqual("2023", year)
+        self.assertEqual("2", period)
+    
+    def test_get_current_year_and_period_with_left_jan_limits(self):
+        year, period = sns.get_current_year_and_period(datetime(2023, 12, 31))
+
+        self.assertEqual("2023", year)
+        self.assertEqual("2", period)
+
+        year, period = sns.get_current_year_and_period(datetime(2024, 1, 1))
+
+        self.assertEqual("2024", year)
+        self.assertEqual("1", period)
+    
+    def test_get_current_year_and_period_with_middle_date(self):
+        year, period = sns.get_current_year_and_period(datetime(2023, 2, 18))
+
+        self.assertEqual("2023", year)
+        self.assertEqual("1", period)
+
+        year, period = sns.get_current_year_and_period(datetime(2023, 9, 20))
+
+        self.assertEqual("2023", year)
+        self.assertEqual("2", period)
+
+        year, period = sns.get_current_year_and_period(datetime(2024, 4, 23))
+
+        self.assertEqual("2024", year)
+        self.assertEqual("1", period)
+
+        year, period = sns.get_current_year_and_period(datetime(2024, 7, 9))
+
+        self.assertEqual("2024", year)
+        self.assertEqual("2", period)
 
     def test_get_next_period(self):
         _, period = sns.get_next_period()
@@ -70,4 +105,3 @@ class DateUtilsTest(APITestCase):
         year, period = sns.get_previous_period(date)
 
         self.assertEqual(str(date.year - (period == '2')), year)
-


### PR DESCRIPTION
**Qual erro encontrado?**
A função `get_current_year_and_period` apresentava um erro nos dias 30 e 31 de Dezembro e retorna ano/períodos não esperados, isso acontecia da seguinte forma:
Verificávamos se a data atual estava entre 01/05/ano e 30/12/ano, caso sim, então o período atual era o 2º, se não era o 1º, mas o erro era utilizar o próprio `current_year` para indicar o ano quando a data estava entre 30 e 31 de dezembro, visto que o período estava correto, mas o ano na verdade é o próximo por que já estamos ao final do atual e queremos atualiza-lo.

**O que foi feito?**
Para arrumar o erro foi atualizada a verificação e agora vemos se está entre 02/05/ano e 01/01/(ano + 1), caso sim, então o périodo é o 2º do `current_year`, se não é o 1º do `current_year` também. Como ficou:

Exemplo com 2023:
Data **antes** de 02/05/2023, então retorna (2023, 1)
Data **entre** 02/05/2023 e 01/01/2024, então retorna (2023, 2)
Data **depois** de 01/01/2024 mas antes de 02/05/2024, então retorna (2024, 1)

A grande mudança é que agora quando a data passa de 01/01/(ano + 1) o `current_year` na verdade já está atualizado e não é mais 2023 e sim 2024 como esperado então podemos simplesmente colocar o período como 1º. Além disso, não temos corner cases visto que a data é comparada por completo e, portanto, 01/01/2024 00:00:00 é diferente de 01/01/2024 00:00:01, o que faz o período somente ser atualizado exatamente se o ano for o próximo como esperado