### PR TITLE
ux(schedule-generator): adiciona mensagem descritiva de conflito de grade horária

### DIFF
--- a/api/api/serializers.py
+++ b/api/api/serializers.py
@@ -46,3 +46,7 @@ class ScheduleSerializer(ModelSerializer):
     class Meta:
         model = Schedule
         exclude = ['user']
+
+class GenerateSchedulesSerializer(serializers.Serializer):
+    message = serializers.CharField(max_length=200)
+    schedules = ClassSerializerSchedule(many=True)

--- a/api/api/tests/test_generate_schedule_api.py
+++ b/api/api/tests/test_generate_schedule_api.py
@@ -36,7 +36,7 @@ class TestGenerateScheduleAPI(APITestCase):
         response = self.client.post(self.api_url, body, content_type=self.content_type)
         
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.data) > 0)
+        self.assertTrue(len(response.data["schedules"]) > 0)
     
     def test_with_conflicting_classes(self):
         """
@@ -50,7 +50,7 @@ class TestGenerateScheduleAPI(APITestCase):
         response = self.client.post(self.api_url, body, content_type=self.content_type)
         
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(len(response.data))
+        self.assertFalse(len(response.data["schedules"]))
     
     def test_with_invalid_class(self):
         """
@@ -121,4 +121,4 @@ class TestGenerateScheduleAPI(APITestCase):
         response = self.client.post(self.api_url, body, content_type=self.content_type)
         
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.data) > 0)
+        self.assertTrue(len(response.data["schedules"]) > 0)

--- a/api/api/tests/test_get_schedules_api.py
+++ b/api/api/tests/test_get_schedules_api.py
@@ -37,8 +37,10 @@ class TestGetSchedules(APITestCase):
         self.url = reverse('api:schedules')
         self.content_type = 'application/json'
 
-        self.schedules = self.client.post(
+        self.data = self.client.post(
             reverse('api:generate-schedules'), body, content_type=self.content_type).data
+        
+        self.schedules = self.data.get('schedules')
 
         self.schedule_json = json.dumps(self.schedules[0])
 

--- a/api/api/tests/test_get_schedules_api.py
+++ b/api/api/tests/test_get_schedules_api.py
@@ -39,7 +39,6 @@ class TestGetSchedules(APITestCase):
 
         self.data = self.client.post(
             reverse('api:generate-schedules'), body, content_type=self.content_type).data
-        
         self.schedules = self.data.get('schedules')
 
         self.schedule_json = json.dumps(self.schedules[0])

--- a/api/api/tests/test_schedule_delete.py
+++ b/api/api/tests/test_schedule_delete.py
@@ -37,8 +37,10 @@ class TestDeleteSchedules(APITestCase):
         self.url = "api:delete-schedule"
         self.content_type = 'application/json'
 
-        self.schedules = self.client.post(
+        self.data = self.client.post(
             reverse('api:generate-schedules'), body, content_type=self.content_type).data
+        
+        self.schedules = self.data.get('schedules')
 
         self.schedule_json = json.dumps(self.schedules[0])
 

--- a/api/api/tests/test_schedule_delete.py
+++ b/api/api/tests/test_schedule_delete.py
@@ -39,7 +39,6 @@ class TestDeleteSchedules(APITestCase):
 
         self.data = self.client.post(
             reverse('api:generate-schedules'), body, content_type=self.content_type).data
-        
         self.schedules = self.data.get('schedules')
 
         self.schedule_json = json.dumps(self.schedules[0])

--- a/api/api/views/save_schedule.py
+++ b/api/api/views/save_schedule.py
@@ -205,9 +205,10 @@ def retrieve_important_params_from_class(_class: dict) -> dict:
 
 def validate_received_schedule(classes_id: list[int]) -> list[Class]:
     schedule_generator = ScheduleGenerator(classes_id)
-    schedules = schedule_generator.generate()
+    generated_data = schedule_generator.generate()
+    schedules = generated_data.get('schedules', None)
 
-    if len(schedules) != 1:
+    if schedules is None or len(schedules) != 1:
         raise ValueError("the classes are not compatible")
 
     return schedules[0]

--- a/api/utils/schedule_generator.py
+++ b/api/utils/schedule_generator.py
@@ -175,7 +175,7 @@ class ScheduleGenerator:
                 continue
 
             for code in schedule_code:
-                if not code in time_from:
+                if code not in time_from:
                     time_from[code] = _class
                     continue
 

--- a/api/utils/schedule_generator.py
+++ b/api/utils/schedule_generator.py
@@ -160,8 +160,8 @@ class ScheduleGenerator:
         ele pode escolher entre remover alguma das disciplinas conflitantes.
 
         :param schedule: Uma grade horária
-        :param time_from: Dicionário com os horários de cada disciplina já adicionada
-        :param first_time: Indica se é a primeira vez que a função é chamada
+        :param except_class: Uma disciplina em que não queremos verificar a existência de conflitos
+        :return: True se a grade horária for válida, False caso contrário
         """
 
         time_from = dict()

--- a/api/utils/schedule_generator.py
+++ b/api/utils/schedule_generator.py
@@ -1,5 +1,5 @@
 from itertools import product
-from collections import defaultdict
+from collections import defaultdict, Counter
 from .db_handler import get_class_by_id
 from re import search
 from api.models import Class
@@ -8,9 +8,13 @@ MAXIMUM_CLASSES_FOR_DISCIPLINE = 4
 MINIMUM_PREFERENCE_RANGE = 1
 MAXIMUM_PREFERENCE_RANGE = 3
 MAXIMUM_DISCIPLINES = 11
+MAXIMUM_DISPLAYED_CONFLICTS = 4
 
 LIMIT_ERROR_MESSAGE = f"you can only send {MAXIMUM_DISCIPLINES} disciplines and {MAXIMUM_CLASSES_FOR_DISCIPLINE} classes for each discipline."
 PREFERENCE_RANGE_ERROR = f"preference must be a list of integers with range [{MINIMUM_PREFERENCE_RANGE}, {MAXIMUM_PREFERENCE_RANGE}]"
+NO_SCHEDULES_ERROR = "Não há horários disponíveis para a combinação de disciplinas selecionadas."
+SUCCESS_MESSAGE = "Horários gerados com sucesso."
+FIX_PROBLEM_MESSAGE = "\n\nPara resolver o problema, você pode remover uma das seguintes disciplinas: \n\n"
 
 def check(function):
     """
@@ -31,16 +35,18 @@ class ScheduleGenerator:
 
     def __init__(self, classes_id: list[int], preference: list = None):
         self.schedule_info = defaultdict(lambda: None)
+        self.conflicting_classes = Counter()
         self.preference = preference
         self.generated = False
         self._validate_preference()
         self._get_and_validate_classes(classes_id=set(classes_id))
         self._make_disciplines_list()
         self._validate_parameters_length()
-    
+
     def _validate_preference(self) -> None:
-        self.valid = self.preference is None or all(isinstance(x, int) and MINIMUM_PREFERENCE_RANGE <= x <= MAXIMUM_PREFERENCE_RANGE for x in self.preference)
-        
+        self.valid = self.preference is None or all(isinstance(
+            x, int) and MINIMUM_PREFERENCE_RANGE <= x <= MAXIMUM_PREFERENCE_RANGE for x in self.preference)
+
         if not self.valid:
             raise ValueError(PREFERENCE_RANGE_ERROR)
 
@@ -136,20 +142,56 @@ class ScheduleGenerator:
         for classes in self.disciplines.values():
             self.disciplines_list.append(classes)
 
-    def _is_valid_schedule(self, schedule: tuple) -> bool:
-        codes_counter = 0
-        schedule_codes = set()
+    def _handle_conflict(self, conflicting_class: Class, schedule: tuple) -> None:
+        # Depois, verificamos se há uma grade horária válida sem a disciplina atual
+        schedule_valid = self._valid_schedule(schedule, conflicting_class)
+
+        # Caso haja, adicionaremos a matéria removida na lista "conflicting_classes"
+        if schedule_valid:
+            self.conflicting_classes[conflicting_class.discipline] += 1
+
+    def _valid_schedule(self, schedule: tuple, except_class: Class = None) -> bool:
+        """
+        Verifica se uma grade horária é válida. Caso não seja, verificamos se há a
+        existência de uma grade horária após remoção de uma das disciplinas conflitantes.
+
+        Caso haja, adicionaremos a matéria removida na lista "conflicting_classes" e,
+        se não houver nenhuma grade horária válida, mostraremos para o usuário que
+        ele pode escolher entre remover alguma das disciplinas conflitantes.
+
+        :param schedule: Uma grade horária
+        :param time_from: Dicionário com os horários de cada disciplina já adicionada
+        :param first_time: Indica se é a primeira vez que a função é chamada
+        """
+
+        time_from = dict()
 
         for class_id in schedule:
             _class = self.classes[class_id]
-
             schedule_code = self.schedule_info[_class.schedule]["times"]
-            codes_counter += len(schedule_code)
-            schedule_codes = schedule_codes.union(schedule_code)
 
-            if codes_counter > len(schedule_codes):
-                """Caso o contador seja maior do que a união dos produtos cartesianos com o horário pretendido,
-                o horário não é válido, pois há horários que se sobrepõem"""
+            # Verificamos se a disciplina atual é a disciplina que queremos remover
+            if _class == except_class:
+                continue
+
+            for code in schedule_code:
+                if not code in time_from:
+                    time_from[code] = _class
+                    continue
+
+                # Caso haja uma "except_class", significa que estamos na etapa de remoção de uma disciplina
+                # conflitante. Portanto, não faremos nada.
+                if except_class is not None:
+                    return False
+
+                conflicting_class = time_from[code]
+
+                # Verificamos a ausência de conflito removendo a disciplina atual
+                self._handle_conflict(_class, schedule)
+
+                # Verificamos a ausência de conflito removendo a disciplina conflitante
+                self._handle_conflict(conflicting_class, schedule)
+
                 return False
 
         return True
@@ -172,10 +214,25 @@ class ScheduleGenerator:
         possible_schedules = product(*self.disciplines_list)
 
         for schedule in possible_schedules:
-            if self._is_valid_schedule(schedule):
+            if self._valid_schedule(schedule):
                 self._add_schedule(schedule)
 
-        return self.sort_by_priority()
+        extra_message = SUCCESS_MESSAGE
+
+        if not len(self.schedules):
+            extra_message = NO_SCHEDULES_ERROR
+
+        # Caso não haja nenhuma grade horária válida, mostraremos para o usuário que
+        # ele pode escolher entre remover alguma das disciplinas conflitantes.
+        if len(self.conflicting_classes):
+            extra_message += FIX_PROBLEM_MESSAGE
+            extra_message += "\n".join(map(
+                lambda discipline: f"- {discipline[0].code}: {discipline[0].name}", self.conflicting_classes.most_common(MAXIMUM_DISPLAYED_CONFLICTS)))
+
+        return {
+            'message': extra_message,
+            'schedules': self.sort_by_priority()
+        }
 
     def sort_by_priority(self):
         self.schedules.sort(key=lambda priority: sum(map(

--- a/api/utils/tests/test_schedule_generator.py
+++ b/api/utils/tests/test_schedule_generator.py
@@ -164,7 +164,6 @@ class TestSchedule(APITestCase):
 
         generated_data = schedule_generator.generate()
         schedules = generated_data["schedules"]
-        
         self.assertEqual(len(schedules), 4)
 
         schedules = schedule_generator.generate()

--- a/api/utils/tests/test_schedule_generator.py
+++ b/api/utils/tests/test_schedule_generator.py
@@ -76,6 +76,20 @@ class TestSchedule(APITestCase):
             special_dates=[],
             discipline=self.discipline_2
         )
+        self.discipline_3 = dbh.get_or_create_discipline(
+            name='CÁLCULO 2',
+            code='MAT519',
+            department=self.department
+        )
+        self.class_7 = dbh.create_class(
+            teachers=['LUIZA YOKO'],
+            classroom='S1',
+            schedule='34T23',
+            days=['Segunda-Feira 10:00 às 11:50', 'Quarta-Feira 10:00 às 11:50'],
+            _class="1",
+            special_dates=[],
+            discipline=self.discipline_3
+        )
 
     def test_with_correct_parameters(self):
         """
@@ -85,9 +99,9 @@ class TestSchedule(APITestCase):
 
         schedule_generator = ScheduleGenerator(classes_id=[
                                                self.class_1.id, self.class_2.id, self.class_3.id, self.class_4.id], preference=[3, 2, 1])
-        schedules = schedule_generator.generate()
+        generated_data = schedule_generator.generate()
 
-        self.assertEqual(len(schedules), 4)
+        self.assertEqual(len(generated_data["schedules"]), 4)
 
     def test_with_higher_classes_limit(self):
         """
@@ -106,10 +120,10 @@ class TestSchedule(APITestCase):
         """
 
         schedule_generator = ScheduleGenerator(
-            classes_id=[self.class_4.id, self.class_6.id])
-        schedules = schedule_generator.generate()
+            classes_id=[self.class_4.id, self.class_6.id, self.class_7.id])
+        generated_data = schedule_generator.generate()
 
-        self.assertFalse(len(schedules))
+        self.assertFalse(len(generated_data["schedules"]))
 
     def test_with_empty_classes(self):
         """
@@ -117,9 +131,9 @@ class TestSchedule(APITestCase):
         """
 
         schedule_generator = ScheduleGenerator(classes_id=[])
-        schedules = schedule_generator.generate()
+        generated_data = schedule_generator.generate()
 
-        self.assertIsNone(schedules)
+        self.assertIsNone(generated_data)
 
     def test_with_invalid_class(self):
         """
@@ -148,7 +162,9 @@ class TestSchedule(APITestCase):
         schedule_generator = ScheduleGenerator(classes_id=[
                                                self.class_1.id, self.class_2.id, self.class_3.id, self.class_4.id], preference=[3, 2, 1])
 
-        schedules = schedule_generator.generate()
+        generated_data = schedule_generator.generate()
+        schedules = generated_data["schedules"]
+        
         self.assertEqual(len(schedules), 4)
 
         schedules = schedule_generator.generate()

--- a/web/app/contexts/SchedulesContext.tsx
+++ b/web/app/contexts/SchedulesContext.tsx
@@ -20,6 +20,11 @@ export interface CloudScheduleType {
     classes: Array<ScheduleClassType>;
 };
 
+export interface ScheduleAPIType {
+    schedules: Array<ScheduleClassType>;
+    message: string;
+};
+
 type SchedulesType = Array<Array<ScheduleClassType>>;
 type SchedulesCloudType = Array<CloudScheduleType>;
 

--- a/web/app/schedules/home/components/GenerateScheduleButton.tsx
+++ b/web/app/schedules/home/components/GenerateScheduleButton.tsx
@@ -10,7 +10,7 @@ import useUser from '@/app/hooks/useUser';
 import Button from '@/app/components/Button';
 import Modal from '@/app/components/Modal/Modal';
 
-import { ScheduleClassType } from '@/app/contexts/SchedulesContext';
+import { ScheduleAPIType, ScheduleClassType } from '@/app/contexts/SchedulesContext';
 
 import generateSchedule, { EachFieldNumber } from '@/app/utils/api/generateSchedule';
 import { errorToast } from '@/app/utils/errorToast';
@@ -54,10 +54,11 @@ export default function GenerateScheduleButton() {
         setLoading(true);
         generateSchedule(classes_id, [morningPreference, afternoonPreference, nightPreference]).then((response) => {
             if (response.status === 200) {
-                const schedules = response.data as Array<ScheduleClassType>;
+                const data = response.data as ScheduleAPIType;
+                const schedules = data.schedules as Array<ScheduleClassType>;
 
-                if (!schedules.length) {
-                    errorToast('Nenhuma grade conseguiu ser gerada!');
+                if (!schedules.length) {                    
+                    errorToast(data.message, data.message.split('\n').length == 1);
                     setLoading(false);
                 } else {
                     setLocalSchedules(schedules);

--- a/web/app/utils/errorToast.ts
+++ b/web/app/utils/errorToast.ts
@@ -1,9 +1,11 @@
 import toast from 'react-hot-toast';
+import React from 'react';
 
-export const errorToast = (message: string) => {
+export const errorToast = (message: string, centered: boolean = true) => {
     toast.error(message, {
+        duration: 5000,
         style: {
-            textAlign: 'center'
-        }
+            textAlign: centered ? 'center' : 'justify'
+        },
     });
 };


### PR DESCRIPTION
**Issue:**
close #187 

**O que foi feito?**
Adicionado mensagens descritivas para grades horárias com conflito. Caso o usuário não consiga gerar nenhuma grade horária válida, o usuário receberá uma mensagem com duração de *5* segundos, mostrando alternativas válidas de remoção de **uma** disciplina, caso houver.

As alterações foram também adaptadas para o front-end.

**Sistema**
Na função de validação de uma grade horária, caso identificado o primeiro conflito, será feita uma verificação, removendo (uma de cada vez) as disciplinas conflitantes. Uma vez que a remoção gera uma grade horária válida, então temos a matéria "geradora do conflito", inserida em um ranking.

O retorno da api, portanto, teve que ser alterado para uma resposta mais padronizada e sem dificuldades para filtragem no front-end. Eu optei por enviar a mensagem completa através do back-end por questões de comodidade, mas cabe discussões (será que um array de disciplinas seria mais interessante?)