### PR TITLE
front(ux): travar seleção de período

### DIFF
--- a/web/app/components/AsideSchedulePopUp/AsideSchedulePopUp.tsx
+++ b/web/app/components/AsideSchedulePopUp/AsideSchedulePopUp.tsx
@@ -1,4 +1,4 @@
-import { LegacyRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import useSelectedClasses from '@/app/hooks/useSelectedClasses';
 import useShowPopUpContent from '@/app/hooks/useShowPopUpContent';
 
@@ -66,6 +66,10 @@ export default function AsideSchedulePopUp(props: AsideSchedulePopUpPropsType) {
     const { showPopUpContent } = useShowPopUpContent();
     const { selectedClasses, setSelectedClasses } = useSelectedClasses();
     const [searchedDisciplineInfos, setSearchedDisciplineInfos] = useState<Array<DisciplineType>>([]);
+
+    useEffect(() => {
+        if (!showPopUpContent) setSearchedDisciplineInfos([]);
+    }, [showPopUpContent, setSearchedDisciplineInfos]);
 
     function handleSelectClass(discipline: DisciplineType, cls: ClassType) {
         const disciplineId = discipline.id;

--- a/web/app/components/AsideSchedulePopUp/Form/DisciplineOptionForm.tsx
+++ b/web/app/components/AsideSchedulePopUp/Form/DisciplineOptionForm.tsx
@@ -46,8 +46,14 @@ function Form(props: FormPropsType) {
 function getYearAndPeriod(text: string) {
     const year = text.split('/')[0] || defaultFormData.year;
     const period = text.split('/')[1] || defaultFormData.period;
-
+    
     return { year, period };
+}
+
+function handleChangeYearAndPeriod(text: string, currentYearPeriod: string, selectedClasses: any, handleSetYearPeriod: () => void) {
+    if (currentYearPeriod && selectedClasses && currentYearPeriod != text) {
+        errorToast('Há disciplinas selecionadas de outro período, não pode haver mistura!');
+    } else handleSetYearPeriod();
 }
 
 export default function DisciplineOptionForm(props: DisciplineOptionFormPropsType) {
@@ -56,21 +62,13 @@ export default function DisciplineOptionForm(props: DisciplineOptionFormPropsTyp
     const [formData, setFormData] = useState(defaultFormData);
 
     useEffect(() => {
-        if (disableDefault || formData != defaultFormData)
-            return;
-        
-        if (selectedClasses.size) {
+        if (!disableDefault && formData == defaultFormData && selectedClasses.size) {
             const { year, period } = getYearAndPeriod(currentYearPeriod);
             setFormData({ ...formData, year: year, period: period });
             setDisableDefault(true);
         }
     }, [disableDefault, currentYearPeriod, formData, selectedClasses]);
     
-    function handleChangeYearAndPeriod(text: string, handleSetYearPeriod: () => void) {
-        if (currentYearPeriod && currentYearPeriod != text && selectedClasses.size) {
-            errorToast('Há disciplinas selecionadas de outro período, não pode haver mistura!');
-        } else handleSetYearPeriod();
-    }
 
     function handleYearAndPeriodChange(event: ChangeEvent<HTMLSelectElement>) {
         const text = event.target.value.trim();
@@ -83,7 +81,7 @@ export default function DisciplineOptionForm(props: DisciplineOptionFormPropsTyp
                 setCurrentYearPeriod(text);
                 setDisableDefault(true);
             };
-            handleChangeYearAndPeriod(text, handleSetYearPeriod);
+            handleChangeYearAndPeriod(text, currentYearPeriod, selectedClasses.size, handleSetYearPeriod);
         }
     }
 

--- a/web/app/components/AsideSchedulePopUp/Form/DisciplineOptionForm.tsx
+++ b/web/app/components/AsideSchedulePopUp/Form/DisciplineOptionForm.tsx
@@ -66,7 +66,7 @@ export default function DisciplineOptionForm(props: DisciplineOptionFormPropsTyp
         }
 
         props.setInfos([]);
-    }, []);
+    }, [disableDefault]);
 
     function handleChangeYearAndPeriod(text: string, handleSetYearPeriod: () => void) {
         if (currentYearPeriod && currentYearPeriod != text && selectedClasses.size) {

--- a/web/app/components/AsideSchedulePopUp/Form/DisciplineOptionForm.tsx
+++ b/web/app/components/AsideSchedulePopUp/Form/DisciplineOptionForm.tsx
@@ -68,7 +68,6 @@ export default function DisciplineOptionForm(props: DisciplineOptionFormPropsTyp
             setDisableDefault(true);
         }
     }, [disableDefault, currentYearPeriod, formData, selectedClasses]);
-    
 
     function handleYearAndPeriodChange(event: ChangeEvent<HTMLSelectElement>) {
         const text = event.target.value.trim();

--- a/web/app/components/AsideSchedulePopUp/Form/DisciplineOptionForm.tsx
+++ b/web/app/components/AsideSchedulePopUp/Form/DisciplineOptionForm.tsx
@@ -64,10 +64,8 @@ export default function DisciplineOptionForm(props: DisciplineOptionFormPropsTyp
             setFormData({ ...formData, year: year, period: period });
             setDisableDefault(true);
         }
-
-        props.setInfos([]);
-    }, [disableDefault]);
-
+    }, [disableDefault, currentYearPeriod, formData, selectedClasses]);
+    
     function handleChangeYearAndPeriod(text: string, handleSetYearPeriod: () => void) {
         if (currentYearPeriod && currentYearPeriod != text && selectedClasses.size) {
             errorToast('Há disciplinas selecionadas de outro período, não pode haver mistura!');

--- a/web/app/components/AsideSchedulePopUp/Form/DisciplineOptionForm.tsx
+++ b/web/app/components/AsideSchedulePopUp/Form/DisciplineOptionForm.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
+import { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from 'react';
 import useYearPeriod from '@/app/hooks/useYearPeriod';
 import useSelectedClasses from '@/app/hooks/useSelectedClasses';
 
@@ -44,8 +44,8 @@ function Form(props: FormPropsType) {
 }
 
 function getYearAndPeriod(text: string) {
-    const year = text.split('/')[0] || '';
-    const period = text.split('/')[1] || '';
+    const year = text.split('/')[0] || defaultFormData.year;
+    const period = text.split('/')[1] || defaultFormData.period;
 
     return { year, period };
 }
@@ -54,6 +54,19 @@ export default function DisciplineOptionForm(props: DisciplineOptionFormPropsTyp
     const { selectedClasses, currentYearPeriod, setCurrentYearPeriod } = useSelectedClasses();
     const [disableDefault, setDisableDefault] = useState(false);
     const [formData, setFormData] = useState(defaultFormData);
+
+    useEffect(() => {
+        if (disableDefault || formData != defaultFormData)
+            return;
+        
+        if (selectedClasses.size) {
+            const { year, period } = getYearAndPeriod(currentYearPeriod);
+            setFormData({ ...formData, year: year, period: period });
+            setDisableDefault(true);
+        }
+
+        props.setInfos([]);
+    }, []);
 
     function handleChangeYearAndPeriod(text: string, handleSetYearPeriod: () => void) {
         if (currentYearPeriod && currentYearPeriod != text && selectedClasses.size) {


### PR DESCRIPTION
**Issue:**
close #189 

**O que foi feito?**
- Quando o usuário já fez seleção de alguma matéria, selecionar o período/ano automaticamente para as próximas matérias.
- Ao fechar a tela de busca, também realiza a limpeza da lista de matérias pesquisadas anteriormente.